### PR TITLE
Use XPath instead of CSS to handle numeric ids in the HTML

### DIFF
--- a/lib/extractor.rb
+++ b/lib/extractor.rb
@@ -214,11 +214,7 @@ class Extractor
 
   def component_have_id?(component, id)
     doc = Nokogiri::HTML.parse(component.contents)
-    find_id = doc.at_css("##{id}")
-    if !find_id.nil?
-      return true
-    end
-    return false
+    !!doc.at_xpath("//*[@id='#{id}']")
   end
 
   def find_chapter_from_components(component, chapters)


### PR DESCRIPTION
The tools crashes with a CSSSyntax err on the EPUB 30 Spec EPUB found at http://idpf.github.io/epub3-samples/samples.html, because of this error

``` ruby
  Nokogiri::CSS::SyntaxError:
            unexpected '.1' after '[#<Nokogiri::CSS::Node:0x0000011d8ec380 @type=:CONDITIONAL_SELECTOR, @value=[#<Nokogiri::CSS::Node:0x0000011d8ec3d0 @type=:ELEMENT_NAME, @value=["*"]>, #<Nokogiri::CSS::Node:0x0000011d8ec510 @type=:ID, @value=["#sec-css-2"]>]>]'
```

An HTML element has an ID containning `.1` but that's not valid for CSS. By using the XPath equivalent, we avoid the problem.
